### PR TITLE
Moved global collections into the Client class

### DIFF
--- a/bleekWare/__init__.py
+++ b/bleekWare/__init__.py
@@ -11,8 +11,14 @@ Bleak.
 MIT license
 """
 
+import logging
 from java import jclass
 from android.os import Build
+
+
+# Set up logging for this module.
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(name='bleakWare')
 
 
 class BLEDevice:


### PR DESCRIPTION
Previously, the `Client` class relied on global collections to exchange data with the Android callback objects. This would cause problems when trying to simultaneously connect to multiple devices. Fixed by moving the global collections into the `Client` class.

A note about member naming conventions: in Python, "true" private members are prefixed by two underscores (`__`), while members prefixed with only one underscore (`_`) are still public, but by convention should not be accessed by external code unless strictly necessary. The committed changes follow this convention, e.g. `Client._received_data` is kept accessible so it can be modified by Android callbacks, while `Client.__services` is only accessed from inside the class itself.

References:

* https://docs.python.org/3/tutorial/classes.html#private-variables